### PR TITLE
Run initial sync at startup and add verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This command will use the configuration you set for the project when you registe
 **Starting**
 * In order to run `code_sync`, you must have an ssh connection open in another window.
 Once you've entered your password there, `code_sync` uses that connection.
-* When you start this script, nothing will be synced until a file in the `local_dir` is touched. This is normal!
 * The destination dir must exist already, but need not be empty.
 
 **Stopping**

--- a/code_sync/code_sync.py
+++ b/code_sync/code_sync.py
@@ -172,7 +172,7 @@ def identify_code_sync_parameters(args) -> Dict:
         parameters['local_dir'] = args.local_dir
         parameters['remote_dir'] = args.remote_dir
         parameters['target'] = args.target
-        parameters['port'] = args.local_dir
+        parameters['port'] = args.port
     return parameters
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='code_sync',
-      version='0.1.0',
+      version='0.2.0',
       description='',
       url='https://github.com/uzh-dqbm-cmi/code-sync',
       packages=find_packages(),


### PR DESCRIPTION
New Features:
* `code_sync` now runs an initial rsync upon startup before running in watch-for-changes mode, so that changes are synced right away.
* Added a `verbose` flag that prints the `rsync` and `watchmedo` shell commands for help in debugging.

Bugfixes:
* Fixes #3, where using command line args instead of the project registration did not work (because the port number was set as the local dir)
* Fixes issue where local dir paths were not expanded, and did not work if contained `~` 