### PR TITLE
Add ability to edit and delete config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This command will use the configuration you set for the project when you registe
     code_sync --local_dir <mylocaldir/> --remote_dir <myremotedir/> --target <ssh_remote> --port 2222\n
 
 #### Edit or delete a registered project
-    code_sync --edit
+    code_sync --edit <project>
+    code_sync --delete <project>
 
 ### Notes
 **Starting**

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This command will use the configuration you set for the project when you registe
 #### Run code_sync with specific parameters
     code_sync --local_dir <mylocaldir/> --remote_dir <myremotedir/> --target <ssh_remote> --port 2222\n
 
+#### Edit or delete a registered project
+    code_sync --edit
 
 ### Notes
 **Starting**

--- a/code_sync/code_sync.py
+++ b/code_sync/code_sync.py
@@ -92,6 +92,16 @@ def create_config_if_not_exists() -> None:
 
 
 def save_config(config: Dict, mode='a') -> None:
+    """
+    Save the code-sync config to file.
+
+    Args:
+        config: The code-sync config dictionary.
+        mode: File mode. May be either 'a' for append or 'w' for write.
+
+    Returns: None
+
+    """
     if mode not in ['a', 'w']:
         raise ValueError(f"Config must be edited in mode 'a' or 'w', received '{mode}'")
 
@@ -101,7 +111,13 @@ def save_config(config: Dict, mode='a') -> None:
         yaml.dump(config, f, default_flow_style=False, indent=4)
 
 
-def get_project_config() -> Dict:
+def get_project_config_from_user() -> Dict:
+    """
+    Ask the user for the information for the project config.
+
+    Returns: A dictionary with the config for the project, including local_dir, target, remote_dir, and port.
+
+    """
     local_dir = input('Path to code_sync on this local machine: ')
     target = input('Destination machine: ')
     remote_dir = input('Path on the destination machine to sync: ')
@@ -134,7 +150,7 @@ def register_project(project: str) -> None:
         raise ValueError(f"Project '{project}' is already registered")
 
     print(f"Registering new project '{project}'")
-    project_config = get_project_config()
+    project_config = get_project_config_from_user()
 
     project_config_entry = {
         project: project_config
@@ -193,13 +209,24 @@ def edit_projects() -> None:
 
 
 def delete_project_from_config(project: str, config: Dict) -> Dict:
+    """Delete a project entry from the config dictionary."""
     config.pop(project)
     return config
 
 
 def edit_project_config(project: str, config: Dict) -> Dict:
+    """
+    Edit the project config entry for a project that already exists in the code-sync config.
+
+    Args:
+        project: The project name (key in the code-sync config).
+        config: The global code-sync config.
+
+    Returns:
+
+    """
     print(f"Enter details for project '{project}'")
-    project_config = get_project_config()
+    project_config = get_project_config_from_user()
     config[project] = project_config
     return config
 

--- a/code_sync/code_sync.py
+++ b/code_sync/code_sync.py
@@ -119,7 +119,7 @@ def get_project_config_from_user() -> Dict:
 
     """
     local_dir = input('Path to code_sync on this local machine: ')
-    target = input('Destination machine: ')
+    target = input('Destination machine (name of ssh config entry): ')
     remote_dir = input('Path on the destination machine to sync: ')
     port = int(input('Port number to use (default 22): ') or "22")
     project_details = {
@@ -184,7 +184,7 @@ def edit_projects() -> None:
     config = original_config.copy()
     print("Options: (e)dit, (d)elete, (n)ext, (s)ave and exit, (q)uit and don't save ")
     for project in original_config:
-        response = input(f"Project '{project} > ")
+        response = input(f"Project '{project}' > ")
         possible_responses = {
             'd': delete_project_from_config,
             'delete': delete_project_from_config,

--- a/code_sync/code_sync.py
+++ b/code_sync/code_sync.py
@@ -173,39 +173,38 @@ def list_projects() -> None:
     print(formatted_keys)
 
 
-def edit_projects() -> None:
-    """Edit and delete the config entries of the registered projects."""
+def delete_project(project_name: str) -> None:
+    """Delete the config entry of the registered project."""
     create_config_if_not_exists()
     original_config = load_config()
     if len(original_config) == 0:
         print('No projects registered')
         return
+    elif project_name not in original_config:
+        raise ValueError(f"Project '{project_name}' does not exist")
 
     config = original_config.copy()
-    print("Options: (e)dit, (d)elete, (n)ext, (s)ave and exit, (q)uit and don't save ")
-    for project in original_config:
-        response = input(f"Project '{project}' > ")
-        possible_responses = {
-            'd': delete_project_from_config,
-            'delete': delete_project_from_config,
-            'e': edit_project_config,
-            'edit': edit_project_config,
-        }
-        if response in ['n', 'next']:
-            continue
-        elif response in ['s', 'save']:
-            break
-        elif response in ['q', 'quit']:
-            print('Quitting without saving.')
-            return
-        elif response in possible_responses:
-            modify_func = possible_responses[response]
-            config = modify_func(project, config)
-        else:
-            print('Invalid input')
+    config = delete_project_from_config(project_name, config)
 
     save_config(config, mode='w')
-    print('Saved edited code-sync config.')
+    print(f'Deleted {project_name} from code-sync config.')
+
+
+def edit_project(project_name: str) -> None:
+    """Edit the config entry of the registered project."""
+    create_config_if_not_exists()
+    original_config = load_config()
+    if len(original_config) == 0:
+        print('No projects registered')
+        return
+    elif project_name not in original_config:
+        raise ValueError(f"Project '{project_name}' does not exist")
+
+    config = original_config.copy()
+    config = edit_project_config(project_name, config)
+
+    save_config(config, mode='w')
+    print(f'Updated code-sync config for project {project_name}.')
 
 
 def delete_project_from_config(project: str, config: Dict) -> Dict:
@@ -266,8 +265,8 @@ def main():
     parser.add_argument('project', nargs='?', default=None)
     parser.add_argument('--register', help='Register a new project to code_sync', required=False)
     parser.add_argument('--list', action='store_true', help='List all registered projects',  required=False)
-    parser.add_argument('--edit', action='store_true', help='Edit and delete the config entries of the registered'
-                                                            ' projects.',  required=False)
+    parser.add_argument('--edit', help='Edit the config for a registered project.',  required=False)
+    parser.add_argument('--delete', help='Delete the config for a registered project.',  required=False)
     parser.add_argument('--local_dir', help='The local code directory you want to sync', required=False)
     parser.add_argument('--remote_dir', help='The remote directory you want to sync', required=False)
     parser.add_argument('--target', help='Specify which remote machine to connect to', required=False)
@@ -280,7 +279,9 @@ def main():
     elif args.list:
         list_projects()
     elif args.edit:
-        edit_projects()
+        edit_project(args.edit)
+    elif args.delete:
+        delete_project(args.delete)
     else:
         params = identify_code_sync_parameters(args)
         code_sync(local_dir=params['local_dir'], remote_dir=params['remote_dir'], target=params['target'],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='code_sync',
-      version='0.2.0',
+      version='0.3.0',
       description='',
       url='https://github.com/uzh-dqbm-cmi/code-sync',
       packages=find_packages(),


### PR DESCRIPTION
You can now edit and delete registered code_sync projects via `code_sync --edit <project>` and `code_sync --delete <project>`.